### PR TITLE
adding support for datadog notifications

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "v0.26.0"
 
 [[projects]]
+  digest = "1:e64fddc819e2abc68792a743dd857c379449a56f2b9eaf030c03fb0ec19de884"
+  name = "github.com/DataDog/datadog-go"
+  packages = ["statsd"]
+  pruneopts = ""
+  revision = "e67964b4021ad3a334e748e8811eb3cd6becbc6e"
+  version = "2.1.0"
+
+[[projects]]
   digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
   name = "github.com/ghodss/yaml"
   packages = ["."]
@@ -484,6 +492,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/DataDog/datadog-go/statsd",
     "github.com/kelseyhightower/envconfig",
     "github.com/nlopes/slack",
     "go.uber.org/ratelimit",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -51,3 +51,7 @@
 [[constraint]]
   name = "go.uber.org/zap"
   version = "1.9.1"
+
+[[constraint]]
+  name = "github.com/DataDog/datadog-go"
+  version = "2.1.0"

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,12 @@ type Env struct {
 	// Configration for Slack
 	SlackToken   string `envconfig:"SLACK_TOKEN"`
 	SlackChannel string `envconfig:"SLACK_CHANNEL"`
+	// Configuration for Datadog
+	DatadogToken   string `envconfig:"DATADOG_TOKEN"`
+	DatadogAddress string `envconfig:"DATADOG_ADDRESS"`
+	// Datadog tags in the format 'environment:test,host:local'
+	DatadogTags     string `envconfig:"DATADOG_TAGS"`
+	DatadogGaugeKey string `envconfig:"DATADOG_GAUGEKEY"`
 }
 
 // ParseEnv function sets to Env struct and verify it.

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mercari/certificate-expiry-monitor-controller/controller"
 	logging "github.com/mercari/certificate-expiry-monitor-controller/log"
 	"github.com/mercari/certificate-expiry-monitor-controller/notifier"
+	"github.com/mercari/certificate-expiry-monitor-controller/notifier/datadog"
 	"github.com/mercari/certificate-expiry-monitor-controller/notifier/log"
 	"github.com/mercari/certificate-expiry-monitor-controller/notifier/slack"
 
@@ -59,6 +60,14 @@ func runMain() int {
 			}
 
 			notifiers[i] = log.NewNotifier(logger)
+		case datadog.String():
+			dd, err := datadog.NewNotifier(env.DatadogToken, env.DatadogAddress, env.DatadogTags, env.DatadogGaugeKey)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "[ERROR] Failed to create datadog notifier: %s\n", err.Error())
+				return 1
+			}
+
+			notifiers[i] = dd
 		default:
 			fmt.Fprintf(os.Stderr, "[ERROR] Unexpected notifier name: %s\n", name)
 			return 1

--- a/notifier/datadog/datadog.go
+++ b/notifier/datadog/datadog.go
@@ -1,0 +1,76 @@
+package datadog
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/mercari/certificate-expiry-monitor-controller/notifier"
+	"github.com/mercari/certificate-expiry-monitor-controller/source"
+)
+
+type Datadog struct {
+	token    string
+	address  string
+	tags     []string
+	gaugekey string
+}
+
+// NewNotifier function returns new instance of Log.
+func NewNotifier(token, address string, tagstr string, gaugekey string) (notifier.Notifier, error) {
+	if token == "" {
+		return nil, errors.New("datadog token is missing")
+	}
+
+	if address == "" {
+		return nil, errors.New("datadog address is missing")
+	}
+	tags := strings.Split(tagstr, ",")
+	return &Datadog{token: token, address: address, tags: tags, gaugekey: gaugekey}, nil
+}
+
+// String function used by pattern match when parse interpret options.
+func String() string {
+	return "datadog"
+}
+
+func pretty(s []string) string {
+	return strings.Replace(strings.ToLower(strings.Join(s, " ")), " ", "_", -1)
+}
+
+// Alert defined by notifier.Notifier interface.
+func (dd *Datadog) Alert(expiration time.Time, ingress *source.Ingress, tls *source.IngressTLS, opt notifier.Option) error {
+	c, err := statsd.New(dd.address)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer c.Close()
+
+	for _, ep := range tls.Endpoints {
+		certs, err := ep.GetCertificates()
+		if err != nil {
+			log.Fatal(err)
+		}
+		cert := certs[0] // only report the first cert in the chain
+		s := fmt.Sprintf("/c:%v/st:%v/l:%v/o:%v/ou:%v/cn:%v",
+			pretty(cert.Subject.Country),
+			pretty(cert.Subject.Province),
+			pretty(cert.Subject.Locality),
+			pretty(cert.Subject.Organization),
+			pretty(cert.Subject.OrganizationalUnit),
+			strings.ToLower(cert.Subject.CommonName))
+		expire := int(expiration.Sub(time.Now()) / 24)
+
+		c.Tags = append(c.Tags, "certificate:"+s)
+		c.Tags = append(c.Tags, dd.tags...)
+		err = c.Gauge(dd.gaugekey, float64(expire), nil, 1)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+	}
+	return nil
+}


### PR DESCRIPTION
Please read the CLA carefully before submitting your contribution to Mercari.
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.

https://www.mercari.com/cla/

## WHAT
Adding support for sending metrics to Datadog. Please note this sends the data as a Gauge.

## WHY
This enables you to create dashboard with a list of certificates and how many days there is left
until they expire


