### PR TITLE
Fix hosts with wildcards

### DIFF
--- a/source/tls_endpoint.go
+++ b/source/tls_endpoint.go
@@ -38,8 +38,8 @@ func NewTLSEndpoint(host string, port string) *TLSEndpoint {
 // GetCertificates tries to get certificates from endpoint using tls.Dial
 func (e *TLSEndpoint) GetCertificates() ([]*x509.Certificate, error) {
 
-	// We cannot connect to Hostnames with wildcards, so replacing with www.
-	hostName := strings.Replace(e.Hostname, "*", "www", -1)
+	// We cannot connect to Hostnames with wildcards, so replacing with cert-test.
+	hostName := strings.Replace(e.Hostname, "*", "cert-test", -1)
 	conn, err := tls.Dial("tcp", hostName+":"+e.Port, &defaultTLSConfig)
 	if err != nil {
 		return nil, err

--- a/source/tls_endpoint.go
+++ b/source/tls_endpoint.go
@@ -3,6 +3,7 @@ package source
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"strings"
 )
 
 var (
@@ -36,7 +37,10 @@ func NewTLSEndpoint(host string, port string) *TLSEndpoint {
 
 // GetCertificates tries to get certificates from endpoint using tls.Dial
 func (e *TLSEndpoint) GetCertificates() ([]*x509.Certificate, error) {
-	conn, err := tls.Dial("tcp", e.Hostname+":"+e.Port, &defaultTLSConfig)
+
+	// We cannot connect to Hostnames with wildcards, so replacing with www.
+	hostName := strings.Replace(e.Hostname, "*", "www", -1)
+	conn, err := tls.Dial("tcp", hostName+":"+e.Port, &defaultTLSConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When using wildcards in Ingress's hostnames, the TCP dialup fails and the endpoint is not monitored. This PR replaces '*' with 'www', which should fix this.

