### PR TITLE
Upgrade go version to 1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ defaults: &defaults
 golang: &golang
   <<: *defaults
   docker:
-    - image: golang:1.11
+    - image: golang:1.12
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.12
 
 WORKDIR /go/src/github.com/mercari/certificate-expiry-monitor-controller
 


### PR DESCRIPTION
## WHAT

This pull request upgrades go version to `1.12`.

## WHY

The latest version of go is 1.12 and it's stable and mature enough 👍 
